### PR TITLE
google-cloud-resource-manager 1.12.5 :snowflake:

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,5 @@
+upload_channels:
+  - sfe1ed40
+  
+channels:
+  - https://staging.continuum.io/prefect/fs/grpc-google-iam-v1-feedstock/pr2/dcf29b3

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,5 +1,2 @@
 upload_channels:
   - sfe1ed40
-  
-channels:
-  - https://staging.continuum.io/prefect/fs/grpc-google-iam-v1-feedstock/pr2/dcf29b3

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,6 +40,7 @@ test:
     - tests
   commands:
     - pip check
+    # noxfile.py#L199
     - set PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python     # [win]
     - export PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python  # [not win]
     - pytest -vv tests

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,28 +1,34 @@
 {% set name = "google-cloud-resource-manager" %}
-{% set version = "1.8.1" %}
+{% set version = "1.12.5" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/google-cloud-resource-manager-{{ version }}.tar.gz
-  sha256: 9e94eff9fe77dc92bf27671e27a35aee64bdd077ca6873919869c5cf52c1ccb4
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_') }}-{{ version }}.tar.gz
+  sha256: b7af4254401ed4efa3aba3a929cb3ddb803fa6baf91a78485e45583597de5891
 
 build:
   number: 0
-  noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
+  skip: true  # [py<37]
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
   host:
-    - python >=3.7
+    - python
     - pip
+    - setuptools
+    - wheel
   run:
-    - python >=3.7
-    - google-api-core-grpc >=1.34.0,<3.0.0dev,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.*,!=2.4.*,!=2.5.*,!=2.6.*,!=2.7.*,!=2.8.*,!=2.9.*,!=2.10.*
-    - proto-plus >=1.22.0,<2.0.0dev
-    - protobuf >=3.19.5,<5.0.0dev,!=3.20.0,!=3.20.1,!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5
+    - python
+    - google-api-core >=1.34.1,<3.0.0dev,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.*,!=2.4.*,!=2.5.*,!=2.6.*,!=2.7.*,!=2.8.*,!=2.9.*,!=2.10.*
+    - google-api-core-grpc
+    # Exclude incompatible versions of `google-auth`
+    # See https://github.com/googleapis/google-cloud-python/issues/12364
+    - google-auth >=2.14.1,<3.0.0dev,!=2.24.0,!=2.25.0
+    - proto-plus >=1.22.3,<2.0.0dev
+    - protobuf >=3.20.2,<6.0.0dev,!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5
     - grpc-google-iam-v1 >=0.12.4,<1.0.0dev
 
 test:
@@ -30,21 +36,31 @@ test:
     - grpc
     - google.cloud.resourcemanager
     - google.cloud.resourcemanager_v3
+  source_files:
+    - tests
   commands:
     - pip check
+    - set PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python     # [win]
+    - export PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python  # [not win]
+    - pytest -vv tests
   requires:
     - pip
+    - pytest
 
 about:
-  home: https://github.com/googleapis/python-resource-manager
+  home: https://github.com/googleapis/google-cloud-python/tree/main/packages/google-cloud-resource-manager
   license: Apache-2.0
   license_family: Apache
   license_file: LICENSE
   summary: Google Cloud Resource Manager API client library
-  description: "Google Cloud Resource Manager API provides methods that you can use to programmatically manage your projects in the Google Cloud Platform. You can create, list, update or delete projects within Google Cloud Platform.\nSee the [quick start guide](https://googleapis.dev/python/cloudresourcemanager/latest/index.html#quick-start)."
-
-  doc_url: https://googleapis.dev/python/cloudresourcemanager/latest/index.html
-  dev_url: https://github.com/googleapis/python-resource-manager
+  description: |
+    Google Cloud Resource Manager API provides methods that you can use
+    to programmatically manage your projects in the Google Cloud Platform.
+    You can create, list, update or delete projects within Google Cloud Platform.
+    
+    See the [quick start guide](https://googleapis.dev/python/cloudresourcemanager/latest/index.html#quick-start).
+  doc_url: https://cloud.google.com/python/docs/reference/cloudresourcemanager/latest/summary_overview
+  dev_url: https://github.com/googleapis/google-cloud-python/tree/main/packages/google-cloud-resource-manager
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
google-cloud-resource-manager 1.12.5 :snowflake:

**Destination channel:** Snowflake

### Links

- [PKG-4548]
- dev_url (pypi): https://github.com/googleapis/google-cloud-python/tree/google-cloud-resource-manager-v1.12.5/packages/google-cloud-resource-manager
- conda-forge: https://github.com/conda-forge/google-cloud-resource-manager-feedstock/blob/main/recipe/meta.yaml
- pypi: https://pypi.org/project/google-cloud-resource-manager/1.12.5
- pypi inspector: https://inspector.pypi.io/project/google-cloud-resource-manager/1.12.5

### Dependency for

- AnacondaRecipes/google-cloud-aiplatform-feedstock/pull/2

### Depends on

- AnacondaRecipes/grpc-google-iam-v1-feedstock#2

### Explanation of changes:

- new feedstock
- upstream tests


[PKG-4548]: https://anaconda.atlassian.net/browse/PKG-4548?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ